### PR TITLE
Remove main.rb from step 2 sample

### DIFF
--- a/step_2/main.rb
+++ b/step_2/main.rb
@@ -1,9 +1,0 @@
-require_relative './calculator'
-
-@calculator = Calculator.new
-
-input = gets.chomp!
-
-exit if input === 'quit'
-
-puts @calculator.calc(input)


### PR DESCRIPTION
I Removed main.rb because I think the users can understand Calculator#calc feature better invoking the method directly in irb.

like this:

```shell
$ irb
irb(main):001:0> require './calculator.rb'
=> true
irb(main):002:0> ca = Calculator.new
=> #<Calculator:0x007f97610a2418 @stack=[]>
irb(main):003:0> ca.calc '1 2 +'
=> 3
irb(main):004:0> ca.calc '1 2 + 4 *'
=> 12
```
