### PR TITLE
Remove \n from list parser

### DIFF
--- a/step_1/pukipa.rb
+++ b/step_1/pukipa.rb
@@ -137,7 +137,7 @@ class Pukipa
       tmp.clear
     end
     result << "</#{list}>"
-    result.join "\n"
+    result.join
   end
 
   # dlのパーサ

--- a/step_1/test/test_pukipa.rb
+++ b/step_1/test/test_pukipa.rb
@@ -9,7 +9,7 @@ class TestPukipa < Minitest::Test
 
   def test_to_html_should_parse_list_element
     pu = Pukipa.new('-リスト表記')
-    str = "<ul>\n<li>リスト表記\n</li>\n</ul>"
+    str = "<ul><li>リスト表記</li></ul>"
     assert_equal str, pu.to_html
   end
 end


### PR DESCRIPTION
I think `list_parse` doesn't have to put `\n` in HTML... :name_badge: 